### PR TITLE
Replace NewFuncLogger with LoggerFunc

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -7,22 +7,14 @@ type Logger interface {
 	Log(ctx context.Context, msg string, keyvals ...interface{})
 }
 
-// LogFunc is a logging function that can be passed to NewFuncLogger
-type LogFunc func(ctx context.Context, msg string, keyvals ...interface{})
-
 type nullLogger struct{}
 
 func (nullLogger) Log(ctx context.Context, msg string, keyvals ...interface{}) {}
 
-type funcLogger struct {
-	logger LogFunc
-}
+// LoggerFunc is an adapter which allows a function to be used as a Logger.
+type LoggerFunc func(ctx context.Context, msg string, keyvals ...interface{})
 
-// NewFuncLogger accepts a logging function and returns a matching Logger for it
-func NewFuncLogger(logger func(ctx context.Context, msg string, keyvals ...interface{})) Logger {
-	return funcLogger{logger: logger}
-}
-
-func (l funcLogger) Log(ctx context.Context, msg string, keyvals ...interface{}) {
-	l.logger(ctx, msg, keyvals...)
+// Log calls f(ctx, msg, keyvals...).
+func (f LoggerFunc) Log(ctx context.Context, msg string, keyvals ...interface{}) {
+	f(ctx, msg, keyvals...)
 }

--- a/sql_example_test.go
+++ b/sql_example_test.go
@@ -16,11 +16,11 @@ import (
 // WrapDriverGoogle demonstrates how to call wrapDriver and register a new driver.
 // This example uses MySQL and google tracing to illustrate this
 func ExampleWrapDriver_google() {
-	logger := func(ctx context.Context, msg string, keyvals ...interface{}) {
+	logger := instrumentedsql.LoggerFunc(func(ctx context.Context, msg string, keyvals ...interface{}) {
 		log.Printf("%s %v", msg, keyvals)
-	}
+	})
 
-	sql.Register("instrumented-mysql", instrumentedsql.WrapDriver(mysql.MySQLDriver{}, instrumentedsql.WithTracer(google.NewTracer()), instrumentedsql.WithLogger(instrumentedsql.NewFuncLogger(logger))))
+	sql.Register("instrumented-mysql", instrumentedsql.WrapDriver(mysql.MySQLDriver{}, instrumentedsql.WithTracer(google.NewTracer()), instrumentedsql.WithLogger(logger)))
 	db, err := sql.Open("instrumented-mysql", "connString")
 
 	// Proceed to handle connection errors and use the database as usual
@@ -30,11 +30,11 @@ func ExampleWrapDriver_google() {
 // WrapDriverOpentracing demonstrates how to call wrapDriver and register a new driver.
 // This example uses MySQL and opentracing to illustrate this
 func ExampleWrapDriver_opentracing() {
-	logger := func(ctx context.Context, msg string, keyvals ...interface{}) {
+	logger := instrumentedsql.LoggerFunc(func(ctx context.Context, msg string, keyvals ...interface{}) {
 		log.Printf("%s %v", msg, keyvals)
-	}
+	})
 
-	sql.Register("instrumented-mysql", instrumentedsql.WrapDriver(mysql.MySQLDriver{}, instrumentedsql.WithTracer(opentracing.NewTracer()), instrumentedsql.WithLogger(instrumentedsql.NewFuncLogger(logger))))
+	sql.Register("instrumented-mysql", instrumentedsql.WrapDriver(mysql.MySQLDriver{}, instrumentedsql.WithTracer(opentracing.NewTracer()), instrumentedsql.WithLogger(logger)))
 	db, err := sql.Open("instrumented-mysql", "connString")
 
 	// Proceed to handle connection errors and use the database as usual
@@ -44,11 +44,11 @@ func ExampleWrapDriver_opentracing() {
 // WrapDriverJustLogging demonstrates how to call wrapDriver and register a new driver.
 // This example uses sqlite, but does not trace, but merely logs all calls
 func ExampleWrapDriver_justLogging() {
-	logger := func(ctx context.Context, msg string, keyvals ...interface{}) {
+	logger := instrumentedsql.LoggerFunc(func(ctx context.Context, msg string, keyvals ...interface{}) {
 		log.Printf("%s %v", msg, keyvals)
-	}
+	})
 
-	sql.Register("instrumented-sqlite", instrumentedsql.WrapDriver(&sqlite3.SQLiteDriver{}, instrumentedsql.WithLogger(instrumentedsql.NewFuncLogger(logger))))
+	sql.Register("instrumented-sqlite", instrumentedsql.WrapDriver(&sqlite3.SQLiteDriver{}, instrumentedsql.WithLogger(logger)))
 	db, err := sql.Open("instrumented-sqlite", "connString")
 
 	// Proceed to handle connection errors and use the database as usual


### PR DESCRIPTION
Similar to http.HandlerFunc, LoggerFunc adapts a function to fulfill the Logger interface directly rather than via a struct.

---

My apologies for not opening an issue discussing the change. Since it's was a small amount of work, I figured it would be easier to let you consider it based on the code.

Thanks!