### PR TITLE
opentracing: handle case where parent span is nil

### DIFF
--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -27,13 +27,22 @@ func (tracer) GetSpan(ctx context.Context) instrumentedsql.Span {
 }
 
 func (s span) NewChild(name string) instrumentedsql.Span {
+	if s.parent == nil {
+		return span{parent: opentracing.StartSpan(name)}
+	}
 	return span{parent: opentracing.StartSpan(name, opentracing.ChildOf(s.parent.Context()))}
 }
 
 func (s span) SetLabel(k, v string) {
+	if s.parent == nil {
+		return
+	}
 	s.parent.SetTag(k, v)
 }
 
 func (s span) Finish() {
+	if s.parent == nil {
+		return
+	}
 	s.parent.Finish()
 }

--- a/opentracing/tracer_test.go
+++ b/opentracing/tracer_test.go
@@ -1,0 +1,38 @@
+package opentracing
+
+import (
+	"context"
+	"testing"
+
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+func TestSpanWithParent(t *testing.T) {
+	ctx := opentracing.ContextWithSpan(
+		context.Background(),
+		opentracing.GlobalTracer().StartSpan("some_span"),
+	)
+
+	tr := NewTracer()
+	span := tr.GetSpan(ctx)
+	span.SetLabel("key", "value")
+
+	child := span.NewChild("child")
+	child.SetLabel("child_key", "child_value")
+	child.Finish()
+
+	span.Finish()
+}
+
+func TestSpanWithoutParent(t *testing.T) {
+	ctx := context.Background() // Background has no span
+	tr := NewTracer()
+	span := tr.GetSpan(ctx)
+	span.SetLabel("key", "value")
+
+	child := span.NewChild("child")
+	child.SetLabel("child_key", "child_value")
+	child.Finish()
+
+	span.Finish()
+}


### PR DESCRIPTION
If there was no parent span in the `ctx` received, the span that's
given out will have a `s.parent == nil`. The `wrappedConn` tries
to use the span nevertheless and this creates a panic by nil pointer
dereference.

Since a nil parent is a valid operation,  the `span` with `parent ==
nil` should be a no-op for methods on it, and creating a new span from
it should make a root span - one that is not a child of another span
context.