### PR TITLE
Remove args label

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -5,7 +5,6 @@ import (
 	"database/sql/driver"
 	"fmt"
 
-	"github.com/kr/pretty"
 	"github.com/pkg/errors"
 )
 
@@ -168,11 +167,10 @@ func (c wrappedConn) ExecContext(ctx context.Context, query string, args []drive
 	span := c.GetSpan(ctx).NewChild("sql-conn-exec")
 	span.SetLabel("component", "database/sql")
 	span.SetLabel("query", query)
-	span.SetLabel("args", pretty.Sprint(args))
 	defer func() {
 		span.SetLabel("err", fmt.Sprint(err))
 		span.Finish()
-		c.Log(ctx, "sql-conn-exec", "query", query, "args", pretty.Sprint(args), "err", err)
+		c.Log(ctx, "sql-conn-exec", "query", query, "err", err)
 	}()
 
 	if execContext, ok := c.parent.(driver.ExecerContext); ok {
@@ -234,11 +232,10 @@ func (c wrappedConn) QueryContext(ctx context.Context, query string, args []driv
 	span := c.GetSpan(ctx).NewChild("sql-conn-query")
 	span.SetLabel("component", "database/sql")
 	span.SetLabel("query", query)
-	span.SetLabel("args", pretty.Sprint(args))
 	defer func() {
 		span.SetLabel("err", fmt.Sprint(err))
 		span.Finish()
-		c.Log(ctx, "sql-conn-query", "query", query, "args", pretty.Sprint(args), "err", err)
+		c.Log(ctx, "sql-conn-query", "query", query, "err", err)
 	}()
 
 	if queryerContext, ok := c.parent.(driver.QueryerContext); ok {
@@ -308,11 +305,10 @@ func (s wrappedStmt) Exec(args []driver.Value) (res driver.Result, err error) {
 	span := s.GetSpan(s.ctx).NewChild("sql-stmt-exec")
 	span.SetLabel("component", "database/sql")
 	span.SetLabel("query", s.query)
-	span.SetLabel("args", pretty.Sprint(args))
 	defer func() {
 		span.SetLabel("err", fmt.Sprint(err))
 		span.Finish()
-		s.Log(s.ctx, "sql-stmt-exec", "query", s.query, "args", pretty.Sprint(args), "err", err)
+		s.Log(s.ctx, "sql-stmt-exec", "query", s.query, "err", err)
 	}()
 
 	res, err = s.parent.Exec(args)
@@ -327,11 +323,10 @@ func (s wrappedStmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 	span := s.GetSpan(s.ctx).NewChild("sql-stmt-query")
 	span.SetLabel("component", "database/sql")
 	span.SetLabel("query", s.query)
-	span.SetLabel("args", pretty.Sprint(args))
 	defer func() {
 		span.SetLabel("err", fmt.Sprint(err))
 		span.Finish()
-		s.Log(s.ctx, "sql-stmt-query", "query", s.query, "args", pretty.Sprint(args), "err", err)
+		s.Log(s.ctx, "sql-stmt-query", "query", s.query, "err", err)
 	}()
 
 	rows, err = s.parent.Query(args)
@@ -346,11 +341,10 @@ func (s wrappedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) 
 	span := s.GetSpan(ctx).NewChild("sql-stmt-exec")
 	span.SetLabel("component", "database/sql")
 	span.SetLabel("query", s.query)
-	span.SetLabel("args", pretty.Sprint(args))
 	defer func() {
 		span.SetLabel("err", fmt.Sprint(err))
 		span.Finish()
-		s.Log(ctx, "sql-stmt-exec", "query", s.query, "args", pretty.Sprint(args), "err", err)
+		s.Log(ctx, "sql-stmt-exec", "query", s.query, "err", err)
 	}()
 
 	if stmtExecContext, ok := s.parent.(driver.StmtExecContext); ok {
@@ -381,11 +375,10 @@ func (s wrappedStmt) QueryContext(ctx context.Context, args []driver.NamedValue)
 	span := s.GetSpan(ctx).NewChild("sql-stmt-query")
 	span.SetLabel("component", "database/sql")
 	span.SetLabel("query", s.query)
-	span.SetLabel("args", pretty.Sprint(args))
 	defer func() {
 		span.SetLabel("err", fmt.Sprint(err))
 		span.Finish()
-		s.Log(ctx, "sql-stmt-query", "query", s.query, "args", pretty.Sprint(args), "err", err)
+		s.Log(ctx, "sql-stmt-query", "query", s.query, "err", err)
 	}()
 
 	if stmtQueryContext, ok := s.parent.(driver.StmtQueryContext); ok {


### PR DESCRIPTION
Remove all the labels and logs that surface parameterized query
arguments, because doing so severely impacts performance due to the use
of github.com/kr/pretty and because parameterized query arguments often
contain sensitive data.

Because parameterized query arguments often contain sensitive data (passwords, api tokens, etc.) or highly regulated data (e.g. HIPAA, GDPR, et al), it's generally a good idea to not log them.