### PR TITLE
Add commonly used functions to wrappedRows that return useful information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-[![GoDoc](https://godoc.org/github.com/ExpansiveWorlds/instrumentedsql?status.svg)](https://godoc.org/github.com/ExpansiveWorlds/instrumentedsql)
+[![GoDoc](https://godoc.org/github.com/lebiathan/instrumentedsql?status.svg)](https://godoc.org/github.com/ExpansiveWorlds/instrumentedsql)
 
 # instrumentedsql
 A sql driver that will wrap any other driver and log/trace all its calls
 
 ## How to use
 
-Please see the [documentation](https://godoc.org/github.com/ExpansiveWorlds/instrumentedsql) and [examples](https://github.com/ExpansiveWorlds/instrumentedsql/blob/master/sql_example_test.go)
+Please see the [documentation](https://godoc.org/github.com/lebiathan/instrumentedsql) and [examples](https://github.com/ExpansiveWorlds/instrumentedsql/blob/master/sql_example_test.go)
 
 ## Roadmap
 

--- a/contributors
+++ b/contributors
@@ -1,2 +1,3 @@
 Luna Duclos
 Dominik Honnef 
+George Valkanas

--- a/google/tracer.go
+++ b/google/tracer.go
@@ -5,7 +5,7 @@ import (
 
 	"cloud.google.com/go/trace"
 
-	"github.com/ExpansiveWorlds/instrumentedsql"
+	"github.com/lebiathan/instrumentedsql"
 )
 
 type tracer struct{}

--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 
-	"github.com/ExpansiveWorlds/instrumentedsql"
+	"github.com/lebiathan/instrumentedsql"
 )
 
 type tracer struct{}

--- a/sql.go
+++ b/sql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
+	"reflect"
 
 	"github.com/kr/pretty"
 	"github.com/pkg/errors"
@@ -453,6 +454,43 @@ func (r wrappedRows) Next(dest []driver.Value) (err error) {
 	}()
 
 	return r.parent.Next(dest)
+}
+
+func (r wrappedRows) ColumnTypeScanType(index int) reflect.Type {
+	if propi, ok := r.parent.(driver.RowsColumnTypeScanType); ok {
+		return propi.ColumnTypeScanType(index)
+	}
+	// We just return a basic interface if anything else failed
+	return reflect.TypeOf(new(interface{})).Elem()
+}
+
+func (r wrappedRows) ColumnTypeDatabaseTypeName(index int) string {
+	if propi, ok := r.parent.(driver.RowsColumnTypeDatabaseTypeName); ok {
+		return propi.ColumnTypeDatabaseTypeName(index)
+	}
+	// If the conversion failed, return an empty string
+	return ""
+}
+
+func (r wrappedRows) ColumnTypeLength(index int) (int64, bool) {
+	if propi, ok := r.parent.(driver.RowsColumnTypeLength); ok {
+		return propi.ColumnTypeLength(index)
+	}
+	return 0, false
+}
+
+func (r wrappedRows) ColumnTypeNullable(index int) (bool, bool) {
+	if propi, ok := r.parent.(driver.RowsColumnTypeNullable); ok {
+		return propi.ColumnTypeNullable(index)
+	}
+	return false, false
+}
+
+func (r wrappedRows) ColumnTypePrecisionScale(index int) (int64, int64, bool) {
+	if propi, ok := r.parent.(driver.RowsColumnTypePrecisionScale); ok {
+		return propi.ColumnTypePrecisionScale(index)
+	}
+	return 0, 0, false
 }
 
 // namedValueToValue is a helper function copied from the database/sql package

--- a/sql_example_test.go
+++ b/sql_example_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/mattn/go-sqlite3"
 
-	"github.com/ExpansiveWorlds/instrumentedsql"
-	"github.com/ExpansiveWorlds/instrumentedsql/google"
-	"github.com/ExpansiveWorlds/instrumentedsql/opentracing"
+	"github.com/lebiathan/instrumentedsql"
+	"github.com/lebiathan/instrumentedsql/google"
+	"github.com/lebiathan/instrumentedsql/opentracing"
 )
 
 // WrapDriverGoogle demonstrates how to call wrapDriver and register a new driver.


### PR DESCRIPTION
In addition to the default interface for Rows, there are several other methods that are used by programs / services on rows, such as getting metadata about the column of a row.

The current implementation does not have any support for such commonly used methods, and though the underlying rows may support / implement them, the wrappedRows interface does not expose them. As a result, we are unable to use that kind of functionality when it is in fact available.

This PR will add support for those methods.